### PR TITLE
header parsing compatible with multiple ':' 

### DIFF
--- a/main.go
+++ b/main.go
@@ -245,7 +245,11 @@ func paramCheck() {
 				continue
 			}
 			kv := strings.Split(v, ":")
-			headers[kv[0]] = kv[1]
+			if len(kv) > 2 {
+				headers[kv[0]] = strings.Join(kv[1:], ":")
+			} else {
+				headers[kv[0]] = kv[1]
+			}
 		}
 	}
 


### PR DESCRIPTION
header parse wrong when contains multiple ':',
like header="columns:c1,c2,deviceip=c1,endtime=date_format(c2, '%Y-%m-%d %H:%i:%s')"