### PR TITLE
[fix]avoid label conflict when setting labels in headers.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,8 @@
 ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 rm -rf version.go
+# Formatting Go code with gofmt
+find . -name '*.go' -exec gofmt -w {} \;
 go generate
 go build
 echo "Build success. Output: ${ROOT}/doris-streamloader"

--- a/loader/stream_loader.go
+++ b/loader/stream_loader.go
@@ -18,20 +18,19 @@
 package loader
 
 import (
+	"doris-streamloader/report"
 	"encoding/json"
 	"fmt"
+	"github.com/pierrec/lz4/v4"
+	log "github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"time"
 	"unicode/utf8"
-
-	"doris-streamloader/report"
-	log "github.com/sirupsen/logrus"
 )
 
 type StreamLoadOption struct {

--- a/loader/stream_loader.go
+++ b/loader/stream_loader.go
@@ -18,19 +18,22 @@
 package loader
 
 import (
-	"doris-streamloader/report"
 	"encoding/json"
 	"fmt"
-	"github.com/pierrec/lz4/v4"
-	log "github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
+
+	lz4 "github.com/pierrec/lz4/v4"
+	log "github.com/sirupsen/logrus"
+
+	"doris-streamloader/report"
 )
 
 type StreamLoadOption struct {

--- a/loader/stream_loader.go
+++ b/loader/stream_loader.go
@@ -18,6 +18,7 @@
 package loader
 
 import (
+	"doris-streamloader/report"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -32,8 +33,6 @@ import (
 
 	lz4 "github.com/pierrec/lz4/v4"
 	log "github.com/sirupsen/logrus"
-
-	"doris-streamloader/report"
 )
 
 type StreamLoadOption struct {

--- a/loader/stream_loader.go
+++ b/loader/stream_loader.go
@@ -31,7 +31,7 @@ import (
 	"time"
 	"unicode/utf8"
 
-	lz4 "github.com/pierrec/lz4/v4"
+	"github.com/pierrec/lz4/v4"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/main.go
+++ b/main.go
@@ -241,11 +241,6 @@ func paramCheck() {
 		os.Exit(1)
 	}
 
-	if userName == "" {
-		log.Errorf("user name is empty")
-		os.Exit(1)
-	}
-
 	// split header "a:b?c:d" into {a:b, c:d}
 	enableConcurrency = true
 	if header != "" {

--- a/main.go
+++ b/main.go
@@ -241,6 +241,11 @@ func paramCheck() {
 		os.Exit(1)
 	}
 
+	if userName == "" {
+		log.Errorf("user name is empty")
+		os.Exit(1)
+	}
+
 	// split header "a:b?c:d" into {a:b, c:d}
 	enableConcurrency = true
 	if header != "" {

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -19,6 +19,8 @@ package file
 
 import (
 	"bufio"
+	"doris-streamloader/loader"
+	"doris-streamloader/report"
 	"io"
 	"os"
 	"path/filepath"
@@ -27,8 +29,6 @@ import (
 	"sync/atomic"
 	"time"
 
-	loader "doris-streamloader/loader"
-	report "doris-streamloader/report"
 	log "github.com/sirupsen/logrus"
 )
 

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -27,9 +27,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-	report "doris-streamloader/report"
 	loader "doris-streamloader/loader"
+	report "doris-streamloader/report"
+	log "github.com/sirupsen/logrus"
 )
 
 type FileReader struct {


### PR DESCRIPTION
When you set `--header="label:label_xxx"` and have more than one worker, it may cause the load job to fail due to label conflicts. This is because the job will be split into multiple tasks, and all these tasks will use the same label. 