### PR TITLE
 [Feature]: Support for Custom Line Break Characters

### DIFF
--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ var (
 	retryInfo            map[int]int
 	showVersion          bool
 	queueSize            int
-	lineDelimiter        byte
+	lineDelimiter        byte = '\n'
 	bufferPool           = sync.Pool{
 		New: func() interface{} {
 			return make([]byte, 0, bufferSize)
@@ -194,6 +194,9 @@ func initFlags() {
 
 // Restore hex escape sequences like \xNN to their corresponding characters
 func restoreHexEscapes(s1 string) (string, error) {
+	if s1 == `\n` {
+		return "\n", nil
+	}
 
 	re := regexp.MustCompile(`\\x([0-9A-Fa-f]{2})`)
 
@@ -274,8 +277,8 @@ func paramCheck() {
 
 				restored, err := restoreHexEscapes(kv[1])
 				if err != nil || len(restored) != 1 {
-					lineDelimiter = '\n'
 					log.Errorf("line_delimiter invalid: %s", kv[1])
+					os.Exit(1)
 				} else {
 					lineDelimiter = restored[0]
 				}

--- a/main.go
+++ b/main.go
@@ -81,8 +81,8 @@ var (
 	retryInfo            map[int]int
 	showVersion          bool
 	queueSize            int
-
-	bufferPool = sync.Pool{
+	line_delimiter       byte
+	bufferPool           = sync.Pool{
 		New: func() interface{} {
 			return make([]byte, 0, bufferSize)
 		},
@@ -186,6 +186,7 @@ func initFlags() {
 		fmt.Println("retry_times: ", maxRetryTimes)
 		fmt.Println("retry_interval: ", retryInterval)
 		fmt.Println("queue_size: ", queueSize)
+		fmt.Println("LineDelimiter: ", string(line_delimiter))
 	}
 
 	utils.InitLog(logLevel)
@@ -253,6 +254,11 @@ func paramCheck() {
 			if strings.ToLower(kv[0]) == "format" && strings.ToLower(kv[1]) != "csv" {
 				enableConcurrency = false
 			}
+
+			if strings.ToLower(kv[0]) == "line_delimiter" && len(kv[1]) == 1 {
+				line_delimiter = kv[1][0]
+			}
+
 			if len(kv) > 2 {
 				headers[kv[0]] = strings.Join(kv[1:], ":")
 			} else {
@@ -369,7 +375,7 @@ func main() {
 		streamLoad.Load(workers, maxRowsPerTask, maxBytesPerTask, &retryInfo)
 		reporter.Report()
 		defer reporter.CloseWait()
-		reader.Read(reporter, workers, maxBytesPerTask, &retryInfo, loadResp, retryCount)
+		reader.Read(reporter, workers, maxBytesPerTask, &retryInfo, loadResp, retryCount, line_delimiter)
 		reader.Close()
 
 		streamLoad.Wait(loadInfo, retryCount, &retryInfo, startTime)

--- a/main.go
+++ b/main.go
@@ -186,7 +186,6 @@ func initFlags() {
 		fmt.Println("retry_times: ", maxRetryTimes)
 		fmt.Println("retry_interval: ", retryInterval)
 		fmt.Println("queue_size: ", queueSize)
-		fmt.Println("LineDelimiter: ", string(line_delimiter))
 	}
 
 	utils.InitLog(logLevel)
@@ -255,9 +254,12 @@ func paramCheck() {
 				enableConcurrency = false
 			}
 
-			if strings.ToLower(kv[0]) == "line_delimiter" && len(kv[1]) == 1 {
-				line_delimiter = kv[1][0]
-			}
+			if strings.ToLower(kv[0]) == "line_delimiter"   {
+				if len(kv[1]) == 1 {
+					line_delimiter = kv[1][0]
+				} else {
+					log.Errorf("line_delimiter invalid: %s", line_delimiter)
+				}
 
 			if len(kv) > 2 {
 				headers[kv[0]] = strings.Join(kv[1:], ":")

--- a/main.go
+++ b/main.go
@@ -82,7 +82,7 @@ var (
 	retryInfo            map[int]int
 	showVersion          bool
 	queueSize            int
-	line_delimiter       byte
+	lineDelimiter        byte
 	bufferPool           = sync.Pool{
 		New: func() interface{} {
 			return make([]byte, 0, bufferSize)
@@ -274,10 +274,10 @@ func paramCheck() {
 
 				restored, err := restoreHexEscapes(kv[1])
 				if err != nil || len(restored) != 1 {
-					line_delimiter = '\n'
+					lineDelimiter = '\n'
 					log.Errorf("line_delimiter invalid: %s", kv[1])
 				} else {
-					line_delimiter = restored[0]
+					lineDelimiter = restored[0]
 				}
 
 			}
@@ -398,7 +398,7 @@ func main() {
 		streamLoad.Load(workers, maxRowsPerTask, maxBytesPerTask, &retryInfo)
 		reporter.Report()
 		defer reporter.CloseWait()
-		reader.Read(reporter, workers, maxBytesPerTask, &retryInfo, loadResp, retryCount, line_delimiter)
+		reader.Read(reporter, workers, maxBytesPerTask, &retryInfo, loadResp, retryCount, lineDelimiter)
 		reader.Close()
 
 		streamLoad.Wait(loadInfo, retryCount, &retryInfo, startTime)

--- a/main.go
+++ b/main.go
@@ -254,12 +254,13 @@ func paramCheck() {
 				enableConcurrency = false
 			}
 
-			if strings.ToLower(kv[0]) == "line_delimiter"   {
+			if strings.ToLower(kv[0]) == "line_delimiter" {
 				if len(kv[1]) == 1 {
 					line_delimiter = kv[1][0]
 				} else {
 					log.Errorf("line_delimiter invalid: %s", line_delimiter)
 				}
+			}
 
 			if len(kv) > 2 {
 				headers[kv[0]] = strings.Join(kv[1:], ":")

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -27,9 +27,9 @@ import (
 	"sync/atomic"
 	"time"
 
-	log "github.com/sirupsen/logrus"
-	report "doris-streamloader/report"
 	loader "doris-streamloader/loader"
+	report "doris-streamloader/report"
+	log "github.com/sirupsen/logrus"
 )
 
 type FileReader struct {
@@ -108,7 +108,8 @@ func NewFileReader(filePaths string, batchRows int, batchBytes int, bufferSize i
 }
 
 // Read File
-func (f *FileReader) Read(reporter *report.Reporter, workers int, maxBytesPerTask int, retryInfo *map[int]int, loadResp *loader.Resp, retryCount int) {
+func (f *FileReader) Read(reporter *report.Reporter, workers int, maxBytesPerTask int, retryInfo *map[int]int,
+	loadResp *loader.Resp, retryCount int, lineDelimiter byte) {
 	index := 0
 	data := f.pool.Get().([]byte)
 	count := f.batchRows
@@ -129,7 +130,7 @@ func (f *FileReader) Read(reporter *report.Reporter, workers int, maxBytesPerTas
 			if atomic.LoadUint64(&reporter.FinishedWorkers) == atomic.LoadUint64(&reporter.TotalWorkers) {
 				return
 			}
-			line, err := reader.ReadBytes('\n')
+			line, err := reader.ReadBytes(lineDelimiter)
 			if err == io.EOF {
 				file.Close()
 				break

--- a/reader/reader.go
+++ b/reader/reader.go
@@ -138,6 +138,9 @@ func (f *FileReader) Read(reporter *report.Reporter, workers int, maxBytesPerTas
 				break
 			} else if err != nil {
 				log.Errorf("Read file failed, error message: %v, before retrying, we suggest:\n1.Check the input data files and fix if there is any problem.\n2.Do select count(*) to check whether data is partially loaded.\n3.If the data is partially loaded and duplication is unacceptable, consider dropping the table (with caution that all data in the table will be lost) and retry.\n4.Otherwise, just retry.\n", err)
+				if len(line) !=0 {
+					log.Error("5.When using a specified line delimiter, the file must end with that delimiter.")
+				}
 				os.Exit(1)
 			}
 


### PR DESCRIPTION
### Background
During usage, it was discovered that the imported text only supported `\n` as the line break character. If the original data contained `\n`, the import process would fail.

### Changes Made
- Modified the default line break character.
- Added support for custom `line_delimiter` through the header, allowing other characters to be used.
- Added support for hexadecimal special characters such as `\x01`.

### Testing
- After modification, the changes have been running in the production environment for over two months, with more than 500 jobs executed successfully.

### Notes
- Due to limitations in Go, the line break character currently supports only single characters, such as `|`. For special characters, hexadecimal ASCII codes can be used.
